### PR TITLE
Socint 256 correct uac authentication pubsub naming

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
-    <version>1.0.52-256-SNAPSHOT</version>
+    <version>1.0.56</version>
   </parent>
 
   <properties>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
   <parent>
     <groupId>ons.sdc.int.common</groupId>
     <artifactId>common</artifactId>
-    <version>1.0.46</version>
+    <version>1.0.52-256-SNAPSHOT</version>
   </parent>
 
   <properties>

--- a/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/data/ExampleData.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/data/ExampleData.java
@@ -108,7 +108,7 @@ public class ExampleData {
   public static UacUpdate createUac(String uacHash, String caseId) {
     UacUpdate uac = new UacUpdate();
     uac.setCaseId(caseId);
-    uac.setActive("true");
+    uac.setActive(true);
     uac.setUacHash(uacHash);
     uac.setQid("3110000009");
     uac.setReceiptReceived(false);

--- a/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/glue/GlueContext.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/glue/GlueContext.java
@@ -14,7 +14,7 @@ import uk.gov.ons.ctp.common.event.model.SurveyLaunchEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchPayload;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchResponse;
 import uk.gov.ons.ctp.common.event.model.SurveyUpdate;
-import uk.gov.ons.ctp.common.event.model.UacAuthenticatePayload;
+import uk.gov.ons.ctp.common.event.model.UacAuthenticationPayload;
 import uk.gov.ons.ctp.common.event.model.UacUpdate;
 import uk.gov.ons.ctp.integration.rhcucumber.data.ExampleData;
 
@@ -34,8 +34,8 @@ public class GlueContext {
   CollectionExercise collectionExercise;
   UacUpdate uacPayload;
   String fulfilmentRequestedCode;
-  Header respondentAuthenticatedHeader;
-  UacAuthenticatePayload respondentAuthenticatedPayload;
+  Header respondentAuthenticationHeader;
+  UacAuthenticationPayload respondentAuthenticationPayload;
   SurveyLaunchEvent surveyLaunchedEvent;
   Header surveyLaunchedHeader;
   SurveyLaunchPayload surveyLaunchedPayload;

--- a/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/glue/RhSteps.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/glue/RhSteps.java
@@ -276,9 +276,9 @@ public class RhSteps extends StepsBase {
     EqValidator.clickThoughToEq(driver, context);
   }
 
-  @Given("an empty queue exists for sending Respondent Authenticated events")
-  public void emptyEventQueueForRespondentAuthenticated() throws Exception {
-    emptyEventQueue(TopicType.UAC_AUTHENTICATE);
+  @Given("an empty queue exists for sending Respondent Authentication events")
+  public void emptyEventQueueForRespondentAuthentication() throws Exception {
+    emptyEventQueue(TopicType.UAC_AUTHENTICATION);
   }
 
   @Given("an empty queue exists for sending Survey Launched events")
@@ -291,9 +291,9 @@ public class RhSteps extends StepsBase {
     emptyEventQueue(TopicType.FULFILMENT);
   }
 
-  @Then("a Respondent Authenticated event is sent to RM")
-  public void verifyRespondentAuthenticatedEventSent() throws Exception {
-    assertNewRespondantAuthenticatedEventHasFired();
+  @Then("a Respondent Authentication event is sent to RM")
+  public void verifyRespondentAuthenticationEventSent() throws Exception {
+    assertNewRespondantAuthenticationEventHasFired();
   }
 
   @Then("a Survey Launched event is sent to RM")
@@ -611,15 +611,15 @@ public class RhSteps extends StepsBase {
     assertTrue(dataRepo.waitForObject(context.uacCollection, context.uacKey, WAIT_TIMEOUT));
   }
 
-  @And("the respondentAuthenticatedHeader contains the correct values")
-  public void theRespondentAuthenticatedHeaderContainsTheCorrectValues() {
-    assertEquals(EventTopic.UAC_AUTHENTICATE, context.respondentAuthenticatedHeader.getTopic());
-    assertEquals(Source.RESPONDENT_HOME.name(), context.respondentAuthenticatedHeader.getSource());
-    assertEquals(Channel.RH, context.respondentAuthenticatedHeader.getChannel());
-    assertNotNull(context.respondentAuthenticatedHeader.getDateTime());
-    assertNotNull(context.respondentAuthenticatedHeader.getMessageId());
-    assertNotNull(context.respondentAuthenticatedPayload.getResponse());
-    assertNotNull(context.respondentAuthenticatedPayload.getResponse().getQuestionnaireId());
+  @And("the respondentAuthenticationHeader contains the correct values")
+  public void theRespondentAuthenticationHeaderContainsTheCorrectValues() {
+    assertEquals(EventTopic.UAC_AUTHENTICATION, context.respondentAuthenticationHeader.getTopic());
+    assertEquals(Source.RESPONDENT_HOME.name(), context.respondentAuthenticationHeader.getSource());
+    assertEquals(Channel.RH, context.respondentAuthenticationHeader.getChannel());
+    assertNotNull(context.respondentAuthenticationHeader.getDateTime());
+    assertNotNull(context.respondentAuthenticationHeader.getMessageId());
+    assertNotNull(context.respondentAuthenticationPayload.getResponse());
+    assertNotNull(context.respondentAuthenticationPayload.getResponse().getQuestionnaireId());
   }
 
   @And("the surveyLaunchedHeader contains the correct values")

--- a/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/glue/StepsBase.java
+++ b/src/test/java/uk/gov/ons/ctp/integration/rhcucumber/glue/StepsBase.java
@@ -11,7 +11,7 @@ import uk.gov.ons.ctp.common.event.TopicType;
 import uk.gov.ons.ctp.common.event.model.FulfilmentEvent;
 import uk.gov.ons.ctp.common.event.model.GenericEvent;
 import uk.gov.ons.ctp.common.event.model.SurveyLaunchEvent;
-import uk.gov.ons.ctp.common.event.model.UacAuthenticateEvent;
+import uk.gov.ons.ctp.common.event.model.UacAuthenticationEvent;
 import uk.gov.ons.ctp.common.pubsub.PubSubHelper;
 import uk.gov.ons.ctp.common.pubsub.SubscriptionSuffix;
 import uk.gov.ons.ctp.common.util.UacUtil;
@@ -114,21 +114,21 @@ public abstract class StepsBase {
     assertNotNull(event.getHeader());
   }
 
-  void assertNewRespondantAuthenticatedEventHasFired() throws Exception {
+  void assertNewRespondantAuthenticationEventHasFired() throws Exception {
 
-    TopicType eventType = TopicType.UAC_AUTHENTICATE;
+    TopicType eventType = TopicType.UAC_AUTHENTICATION;
 
-    UacAuthenticateEvent event =
-        (UacAuthenticateEvent)
+    UacAuthenticationEvent event =
+        (UacAuthenticationEvent)
             pubSub.getMessage(eventType, eventClass(eventType), PUBSUB_TIMEOUT_MS, SubscriptionSuffix.CUC);
 
     assertNotNull(event);
 
-    context.respondentAuthenticatedHeader = event.getHeader();
-    assertNotNull(context.respondentAuthenticatedHeader);
+    context.respondentAuthenticationHeader = event.getHeader();
+    assertNotNull(context.respondentAuthenticationHeader);
 
-    context.respondentAuthenticatedPayload = event.getPayload();
-    assertNotNull(context.respondentAuthenticatedPayload);
+    context.respondentAuthenticationPayload = event.getPayload();
+    assertNotNull(context.respondentAuthenticationPayload);
   }
 
   void assertNewSurveyLaunchedEventHasFired() throws Exception {
@@ -166,8 +166,8 @@ public abstract class StepsBase {
     switch (eventType) {
       case FULFILMENT:
         return FulfilmentEvent.class;
-      case UAC_AUTHENTICATE:
-        return UacAuthenticateEvent.class;
+      case UAC_AUTHENTICATION:
+        return UacAuthenticationEvent.class;
       case SURVEY_LAUNCH:
         return SurveyLaunchEvent.class;
       default:

--- a/src/test/resources/features/UAC-Authentication-Success.feature
+++ b/src/test/resources/features/UAC-Authentication-Success.feature
@@ -3,8 +3,8 @@
 #Feature:  UAC-Authentication-Success
 #Scenario Outline: [CR-T163] The Happy Path - Access the Survey Questionnaire
 #Scenario: [CR-T167] The Happy Path - Access the Survey Questionnaire - Wales
-#Scenario  [CR-T163, CR-T164, CR-T165, CR-T166] Check a Respondent Authenticated event is sent to RM after UAC authentication
-#Scenario: [CR-T167, CR-T168] Check a Respondent Authenticated event is sent to RM after UAC authentication - Wales
+#Scenario  [CR-T163, CR-T164, CR-T165, CR-T166] Check a Respondent Authentication event is sent to RM after UAC authentication
+#Scenario: [CR-T167, CR-T168] Check a Respondent Authentication event is sent to RM after UAC authentication - Wales
 #Scenario  [CR-T163, CR-T164, CR-T165, CR-T166] Check a Survey Launched event is sent to RM after address confirmed
 
 
@@ -50,14 +50,14 @@ Feature:  UAC-Authentication-Success
   ## When RM sends the case_created and uac <eventType> events to RH via RabbitMQ
   ## Then a valid uac exists in Firestore ready for use by a respondent
   @UAC-Authentication-Success-TestT166First @Setup @TearDown
-  Scenario Outline: [CR-T163, CR-T164, CR-T165, CR-T166] Check a Respondent Authenticated event is sent to RM after UAC authentication
+  Scenario Outline: [CR-T163, CR-T164, CR-T165, CR-T166] Check a Respondent Authentication event is sent to RM after UAC authentication
     Given SETUP-3 - a valid uac exists in Firestore and there is an associated case in Firestore ENG eventType <eventType>
-    Given an empty queue exists for sending Respondent Authenticated events
+    Given an empty queue exists for sending Respondent Authentication events
     And I am a respondent and I am on the RH Start Page
     When I enter the valid UAC into the text box
     And I click the “Access survey” button
-    Then a Respondent Authenticated event is sent to RM
-    And the respondentAuthenticatedHeader contains the correct values
+    Then a Respondent Authentication event is sent to RM
+    And the respondentAuthenticationHeader contains the correct values
 
     Examples:
       | eventType     |
@@ -68,14 +68,14 @@ Feature:  UAC-Authentication-Success
   ##  When RM sends the case_created and a uac_updated events to RH via RabbitMQ
   ##  Then a valid uac exists in Firestore ready for use by a respondent
   @UAC-Authentication-Success-WalesTestT168Third @Setup @TearDown
-  Scenario: [CR-T167, CR-T168] Check a Respondent Authenticated event is sent to RM after UAC authentication - Wales
+  Scenario: [CR-T167, CR-T168] Check a Respondent Authentication event is sent to RM after UAC authentication - Wales
     Given SETUP-4 - a valid uac and associated case exist in Firestore with region WALES
-    Given an empty queue exists for sending Respondent Authenticated events
+    Given an empty queue exists for sending Respondent Authentication events
     And I am a respondent and I am on the RH Start Page
     When I enter the valid UAC into the text box
     And I click the “Access survey” button
-    Then a Respondent Authenticated event is sent to RM
-    And the respondentAuthenticatedHeader contains the correct values
+    Then a Respondent Authentication event is sent to RM
+    And the respondentAuthenticationHeader contains the correct values
 
   ##SETUP calls the following steps...
   ## Given RM constructs a case_created event and a uac_updated event
@@ -84,11 +84,11 @@ Feature:  UAC-Authentication-Success
   @UAC-Authentication-Success-TestT166Second @Setup @TearDown
   Scenario Outline: [CR-T163, CR-T164, CR-T165, CR-T166] Check a Survey Launched event is sent to RM after address confirmed
     Given SETUP-3 - a valid uac exists in Firestore and there is an associated case in Firestore ENG eventType <eventType>
-    Given an empty queue exists for sending Respondent Authenticated events
+    Given an empty queue exists for sending Respondent Authentication events
     And I am a respondent and I am on the RH Start Page
     When I enter the valid UAC into the text box
     And I click the “Access survey” button
-    Then a Respondent Authenticated event is sent to RM
+    Then a Respondent Authentication event is sent to RM
     Given I am presented with a page to confirm my address
     When I select the “Yes, this address is correct” option
     And an empty queue exists for sending Survey Launched events


### PR DESCRIPTION
Knock-on changes caused by renaming the 'authenticate' topic+subscription to 'authentication'.