### PR TITLE
Update ports for running RH in our docker dev

### DIFF
--- a/scripts/envCheck.sh
+++ b/scripts/envCheck.sh
@@ -8,8 +8,8 @@
 #
 
 mock_envoy_port="8181" 
-mock_ai_port="8162"
-pubsub_emulator_port="9808"
+mock_ai_port="8163"
+pubsub_emulator_port="8538"
 redis_port="6379"
 rh_service_port="8071"
 rhui_port="9092"

--- a/src/test/resources/application-local.yml
+++ b/src/test/resources/application-local.yml
@@ -1,4 +1,4 @@
 pubsub:
   emulator:
-    host: localhost:9808
+    host: localhost:8538
     use: true

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -46,9 +46,9 @@ cloudStorage:
   uacSchemaName: uac
 
 pubsub:
-  projectid: local
+  projectid: shared-project
   emulator:
-    host: localhost:9808
+    host: localhost:8538
     use: true
 
 spring:


### PR DESCRIPTION
Some ports have needed to be changed to run using RH brought up by using ssdc-rm-docker-dev.

Use the docker dev on the [branch of the same name](https://github.com/ONSdigital/ssdc-rm-docker-dev/pull/51) to start the RH services and `./run.sh` to run the cucumber tests.

https://trello.com/c/zPH8WtWD/3401-bring-rh-into-our-docker-compose-setup8